### PR TITLE
Améliore la mise en page responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,17 +4,30 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>VHP Dashboard avec Ticker</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <style>
-    body {
-      font-family: 'Helvetica Neue', sans-serif;
+    :root {
+      --primary-color: #007bff;
+      --bg-light: #f5f6fa;
+    }
+    html, body {
+      height: 100%;
       margin: 0;
-      background: #f5f6fa;
+    }
+    body {
+      display: flex;
+      flex-direction: column;
+      font-family: 'Inter', sans-serif;
+      background: var(--bg-light);
       color: #333;
+      overflow: hidden;
     }
     #ticker-container {
       overflow: hidden;
       white-space: nowrap;
-      background: #007bff;
+      background: linear-gradient(90deg, var(--primary-color), #00aaff);
       color: white;
       padding: 0.5em 1em;
       font-weight: bold;
@@ -31,16 +44,28 @@
       100% { transform: translateX(-100%); }
     }
     .container {
+      flex: 1;
+      max-width: 1000px;
+      margin: 0 auto;
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-      gap: 1rem;
-      padding: 1rem;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      grid-auto-rows: 1fr;
+      gap: 0.5rem;
+      padding: 0.5rem;
+      overflow: hidden;
     }
     .block {
       background: white;
       border-radius: 12px;
-      padding: 1rem;
-      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+      padding: 0.5rem;
+      box-shadow: 0 4px 10px rgba(0,0,0,0.08);
+      transition: transform 0.2s;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .block:hover {
+      transform: translateY(-3px);
     }
     .block-title {
       margin-top: 0;
@@ -49,25 +74,27 @@
       color: #007bff;
     }
     .block-update {
-      font-size: 0.85em;
+      font-size: 0.75em;
       color: #666;
-      margin-bottom: 0.8em;
+      margin-bottom: 0.4em;
       font-style: italic;
     }
     .block-content {
       white-space: pre-line;
-      line-height: 1.5;
-      font-size: 1em;
+      line-height: 1.4;
+      font-size: 0.9em;
       color: #222;
+      overflow-y: auto;
+      flex: 1;
     }
     .block-content br {
       margin-bottom: 0.5em;
       display: block;
     }
     @media (max-width: 600px) {
-      .container {
-        grid-template-columns: 1fr;
-      }
+      #ticker-container { font-size: 1em; }
+      .container { grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+      .block-title { font-size: 1em; }
     }
   </style>
 </head>

--- a/script.js
+++ b/script.js
@@ -106,12 +106,17 @@ async function fetchTraffic(lineId) {
 
 async function updateStop(elementIdPrefix, stopIds, lineId) {
   updateElementTime(`${elementIdPrefix}-update`);
-  const [tripsText, trafficText] = await Promise.all([
-    processTrips(stopIds),
-    processTraffic(lineId)
-  ]);
-  const finalText = tripsText + "\n\n🚦 Info trafic :\n" + trafficText;
-  updateElementText(elementIdPrefix, finalText);
+  try {
+    const [tripsText, trafficText] = await Promise.all([
+      processTrips(stopIds),
+      processTraffic(lineId)
+    ]);
+    const finalText = tripsText + "\n\n🚦 Info trafic :\n" + trafficText;
+    updateElementText(elementIdPrefix, finalText);
+  } catch (e) {
+    console.warn(`Erreur updateStop ${elementIdPrefix}:`, e);
+    updateElementText(elementIdPrefix, "⚠️ Données indisponibles");
+  }
 }
 
 function updateElementTime(elementId) {


### PR DESCRIPTION
## Summary
- restructure page layout to fit on one screen and avoid page scroll
- adjust block styling for compact display on small screens

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_685fddb0d0f08333834b9f603d9e67b6